### PR TITLE
Fix up the redis cache

### DIFF
--- a/lib/fastentry.rb
+++ b/lib/fastentry.rb
@@ -21,14 +21,10 @@ module Fastentry
     def self.for(cache)
       if ::Rails::VERSION::MAJOR >= 5
         case cache
-        when ActiveSupport::Cache::Strategy::LocalCache
-          DefaultCache.new(cache)
-        when ActiveSupport::Cache::FileStore
-          DefaultCache.new(cache)
-        when ActiveSupport::Cache::MemoryStore
-          DefaultCache.new(cache)
         when ActiveSupport::Cache::RedisCacheStore
           RedisCache.new(cache)
+        when ActiveSupport::Cache::Strategy::LocalCache
+          DefaultCache.new(cache)
         else
           raise ArgumentError, 'Unsupported cache type'
         end


### PR DESCRIPTION
Since redis includes the LocalCache module, it hits that clause and then returns a default cache, which breaks the redis cache key fetching.

Additionally, you shouldn't need to check FileStore or MemoryStore as they both include the LocalCache module.